### PR TITLE
Add base setup for prisma

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Environment variables declared in this file are automatically made available to Prisma.
+# See the documentation for more detail: https://pris.ly/d/prisma-schema#accessing-environment-variables-from-the-schema
+
+# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
+# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
+
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/meny?schema=meny"

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ lerna-debug.log*
 !.vscode/extensions.json
 
 docker-compose.env
+.env

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,11 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}


### PR DESCRIPTION
### Context

Adding base setup for prisma, which we will use as our ORM (at least for the time being).

### Content

Simply initiating the prisma base config with `npx prisma init`