### PR TITLE
Fix server startup

### DIFF
--- a/env/development.example.env
+++ b/env/development.example.env
@@ -1,4 +1,3 @@
-API_HOST="localhost"
 API_PORT=3000
 
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/meny?schema=meny"

--- a/src/application/server.ts
+++ b/src/application/server.ts
@@ -6,8 +6,6 @@ import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
 
 export class Server {
-  private readonly host: string = ApiConfig.HOST;
-
   private readonly port: number = ApiConfig.PORT;
 
   public async run(): Promise<void> {
@@ -16,13 +14,10 @@ export class Server {
 
     this.log();
 
-    await app.listen(this.port, this.host);
+    await app.listen(this.port);
   }
 
   private log(): void {
-    Logger.log(
-      `Server started on host: ${this.host}; port: ${this.port};`,
-      Server.name,
-    );
+    Logger.log(`Ready, listening on port ${this.port};`, Server.name);
   }
 }

--- a/src/infrastructure/config/Api.ts
+++ b/src/infrastructure/config/Api.ts
@@ -1,8 +1,6 @@
 import { get } from 'env-var';
 
 export class ApiConfig {
-  public static readonly HOST: string = get('API_HOST').required().asString();
-
   public static readonly PORT: number = get('API_PORT')
     .required()
     .asPortNumber();


### PR DESCRIPTION
Specifying the hostname in this manner is not necessary and does not seem to work properly, let's just remove it for the time being.