### PR TITLE
Fix API PORT env var name

### DIFF
--- a/env/development.example.env
+++ b/env/development.example.env
@@ -1,3 +1,3 @@
-API_PORT=3000
+PORT=3000
 
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/meny?schema=meny"

--- a/env/test.example.env
+++ b/env/test.example.env
@@ -1,4 +1,3 @@
-API_HOST="localhost"
-API_PORT=3000
+PORT=3000
 
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/meny?schema=meny"

--- a/src/infrastructure/config/Api.ts
+++ b/src/infrastructure/config/Api.ts
@@ -1,7 +1,5 @@
 import { get } from 'env-var';
 
 export class ApiConfig {
-  public static readonly PORT: number = get('API_PORT')
-    .required()
-    .asPortNumber();
+  public static readonly PORT: number = get('PORT').required().asPortNumber();
 }


### PR DESCRIPTION
Scalingo, which we will use for deployments for now, specifies the "PORT" env variable should be used to define which port our app is listening to, the API_PORT variable we were using simply does not work.

