### PR TITLE
Fetch recipes

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,4 +8,6 @@ RUN npm install
 
 COPY . .
 
+RUN npx prisma generate
+
 CMD [ "npm", "run", "start:dev" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile.dev
+    depends_on:
+      - meny-db
     env_file: env/development.env
     environment:
       - NODE_ENV=${NODE_ENV:-development}
@@ -17,7 +19,7 @@ services:
       - ./test:/opt/meny/test
 
   meny-db:
-    container_name: product-builder-service-runtime
+    container_name: meny-db
     image: postgres:15.2-alpine
     restart: always
     env_file: env/postgres.env

--- a/env/development.example.env
+++ b/env/development.example.env
@@ -1,4 +1,4 @@
 PORT=3000
 API_VERSION=0.1
 
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/meny?schema=meny"
+DATABASE_URL="postgresql://postgres:postgres@meny-db:5432/meny?schema=meny&connect_timeout=300"

--- a/src/application/modules/RecipeModule.ts
+++ b/src/application/modules/RecipeModule.ts
@@ -3,11 +3,13 @@ import { RecipeService } from '@core/services/Recipe';
 import { Module } from '@nestjs/common';
 import { RecipeRepository } from '@infrastructure/adapter/repository/Recipe';
 import { RecipeTokens } from '@core/domain/di/tokens/Recipe';
+import { PrismaClient } from '@infrastructure/adapter/prisma/client/PrismaClient';
 
 @Module({
   imports: [],
   controllers: [RecipeController],
   providers: [
+    PrismaClient,
     { provide: RecipeTokens.RecipePort, useClass: RecipeRepository },
     { provide: RecipeTokens.RecipeUseCase, useClass: RecipeService },
   ],

--- a/src/application/modules/RecipeModule.ts
+++ b/src/application/modules/RecipeModule.ts
@@ -8,8 +8,8 @@ import { RecipeTokens } from '@core/domain/di/tokens/Recipe';
   imports: [],
   controllers: [RecipeController],
   providers: [
-    RecipeService,
-    { provide: RecipeTokens.RecipeUseCase, useClass: RecipeRepository },
+    { provide: RecipeTokens.RecipePort, useClass: RecipeRepository },
+    { provide: RecipeTokens.RecipeUseCase, useClass: RecipeService },
   ],
 })
 export class RecipeModule {}

--- a/src/core/domain/di/tokens/Recipe.ts
+++ b/src/core/domain/di/tokens/Recipe.ts
@@ -1,3 +1,4 @@
 export enum RecipeTokens {
   RecipeUseCase = 'RECIPE_USE_CASE',
+  RecipePort = 'RECIPE_PORT',
 }

--- a/src/core/domain/entities/recipe.ts
+++ b/src/core/domain/entities/recipe.ts
@@ -4,17 +4,17 @@ import { Season } from '../../common/enums/season';
 export class Recipe {
   id: number;
   userId: number;
-  cooking?: number;
-  description?: string;
+  cooking?: number | null;
+  description?: string | null;
   ingredients: string[];
-  name?: string;
-  note?: string;
-  preparation?: number;
-  price?: number;
-  season?: Season;
-  servings?: number;
+  name?: string | null;
+  note?: string | null;
+  preparation?: number | null;
+  price?: number | null;
+  season: `${Season}`;
+  servings?: number | null;
   steps: string[];
-  type?: RecipeType;
-  createdAt: string;
-  updatedAt: string;
+  type: `${RecipeType}`;
+  createdAt: Date;
+  updatedAt: Date;
 }

--- a/src/core/services/Recipe.ts
+++ b/src/core/services/Recipe.ts
@@ -1,13 +1,20 @@
 import { FindOptions } from '@core/common/persistence/options';
+import { RecipeTokens } from '@core/domain/di/tokens/Recipe';
 import { Recipe } from '@core/domain/entities/recipe';
 import { RecipePort } from '@core/domain/ports/Recipe';
 import { RecipeUseCases } from '@core/domain/usecases/Recipe';
+import { Inject, Injectable } from '@nestjs/common';
 
+@Injectable()
 export class RecipeService implements RecipeUseCases {
-  constructor(private readonly recipePort: RecipePort) {}
+  constructor(
+    @Inject(RecipeTokens.RecipePort)
+    private readonly recipePort: RecipePort,
+  ) {}
 
   public async getList(options?: FindOptions): Promise<Recipe[]> {
     const recipes = await this.recipePort.getList(options);
+
     return recipes;
   }
 }

--- a/src/infrastructure/adapter/prisma/client/PrismaClient.ts
+++ b/src/infrastructure/adapter/prisma/client/PrismaClient.ts
@@ -1,0 +1,15 @@
+import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
+import { PrismaClient as BasePrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaClient extends BasePrismaClient implements OnModuleInit {
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async enableShutdownHooks(app: INestApplication) {
+    this.$on('beforeExit', async () => {
+      await app.close();
+    });
+  }
+}

--- a/src/infrastructure/adapter/repository/Recipe.ts
+++ b/src/infrastructure/adapter/repository/Recipe.ts
@@ -3,7 +3,9 @@ import { RecipeType } from '@core/common/enums/recipe-type';
 import { Season } from '@core/common/enums/season';
 import { Recipe } from '@core/domain/entities/recipe';
 import { RecipePort } from '@core/domain/ports/Recipe';
+import { Injectable } from '@nestjs/common';
 
+@Injectable()
 export class RecipeRepository implements RecipePort {
   public async getList(options?: FindOptions): Promise<Recipe[]> {
     // TODO: Fetch from db once it has been properly setup and data has been imported

--- a/src/infrastructure/adapter/repository/Recipe.ts
+++ b/src/infrastructure/adapter/repository/Recipe.ts
@@ -1,32 +1,20 @@
 import { FindOptions } from '@core/common/persistence/options';
-import { RecipeType } from '@core/common/enums/recipe-type';
-import { Season } from '@core/common/enums/season';
 import { Recipe } from '@core/domain/entities/recipe';
 import { RecipePort } from '@core/domain/ports/Recipe';
 import { Injectable } from '@nestjs/common';
+import { PrismaClient } from '../prisma/client/PrismaClient';
+import { Recipe as PrismaRecipe } from '@prisma/client';
 
 @Injectable()
 export class RecipeRepository implements RecipePort {
+  constructor(private readonly prisma: PrismaClient) {}
+
   public async getList(options?: FindOptions): Promise<Recipe[]> {
-    // TODO: Fetch from db once it has been properly setup and data has been imported
-    return [
-      {
-        id: 1,
-        userId: 1,
-        cooking: 10,
-        description: 'description',
-        ingredients: ['ingredient'],
-        name: 'Name',
-        note: 'Note',
-        preparation: 15,
-        price: 1000,
-        season: Season.Unspecified,
-        servings: 2,
-        steps: ['Step'],
-        type: RecipeType.Unspecified,
-        createdAt: '2023-01-01',
-        updatedAt: '2023-01-01',
-      },
-    ];
+    const recipes: PrismaRecipe[] = await this.prisma.recipe.findMany({
+      skip: options?.offset,
+      take: options?.limit,
+    });
+
+    return recipes;
   }
 }


### PR DESCRIPTION
### Context

For now we were returned a hardcoded receipe from the `GET /recipes` endpoint, in this PR we want to add the actual implementation that will retrieve records from our db.

### Content 

* Creation of a nest PrismaClient provider
* Adjust the RecipeRepository to use that client over the hardcoded results
* Adjust some issues with the docker config