### PR TITLE
Add List options query params to GET recipes endpoint

### DIFF
--- a/env/development.example.env
+++ b/env/development.example.env
@@ -1,4 +1,6 @@
 PORT=3000
 API_VERSION=0.1
 
+DEFAULT_PAGE_SIZE=50
+
 DATABASE_URL="postgresql://postgres:postgres@meny-db:5432/meny?schema=meny&connect_timeout=300"

--- a/env/test.example.env
+++ b/env/test.example.env
@@ -1,4 +1,6 @@
 PORT=3000
 API_VERSION=0.1
 
+DEFAULT_PAGE_SIZE=50
+
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/meny?schema=meny"

--- a/src/application/api/controllers/RecipeController.ts
+++ b/src/application/api/controllers/RecipeController.ts
@@ -1,8 +1,17 @@
-import { Controller, Get, HttpStatus, Inject } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  HttpStatus,
+  Inject,
+  Query,
+  ValidationPipe,
+} from '@nestjs/common';
 import { RecipeUseCases } from '@core/domain/usecases/Recipe';
 import { RecipeTokens } from '@core/domain/di/tokens/Recipe';
 import { ApiResponse } from '@nestjs/swagger';
 import { RecipeDtoList } from '@core/domain/dto/recipe/RecipeDtoList';
+import { ListOptionsQueryDto } from '@core/common/dto/ListOptionsQueryDto';
+import { queryValidationPipeConfig } from './config/pipes';
 
 @Controller('recipes')
 export class RecipeController {
@@ -13,7 +22,10 @@ export class RecipeController {
 
   @Get()
   @ApiResponse({ status: HttpStatus.OK, type: RecipeDtoList })
-  getRecipes(): Promise<RecipeDtoList> {
-    return this.recipeUseCases.getList();
+  getRecipes(
+    @Query(new ValidationPipe(queryValidationPipeConfig))
+    query: ListOptionsQueryDto,
+  ): Promise<RecipeDtoList> {
+    return this.recipeUseCases.getList(query);
   }
 }

--- a/src/application/api/controllers/config/pipes.ts
+++ b/src/application/api/controllers/config/pipes.ts
@@ -1,0 +1,8 @@
+export const queryValidationPipeConfig = {
+  whitelist: true,
+  forbidNonWhitelisted: true,
+  transform: true,
+  transformOptions: {
+    enableImplicitConversion: true,
+  },
+};

--- a/src/core/common/dto/ListOptionsQueryDto.ts
+++ b/src/core/common/dto/ListOptionsQueryDto.ts
@@ -1,0 +1,12 @@
+import { FindOptions } from '../persistence/options';
+import { IsNumber, IsOptional } from 'class-validator';
+
+export class ListOptionsQueryDto implements FindOptions {
+  @IsOptional()
+  @IsNumber()
+  public take?: number;
+
+  @IsOptional()
+  @IsNumber()
+  public skip?: number;
+}

--- a/src/core/common/persistence/options.ts
+++ b/src/core/common/persistence/options.ts
@@ -1,4 +1,5 @@
-export type FindOptions = {
+export interface FindOptions {
   take?: number;
+
   skip?: number;
-};
+}

--- a/src/core/common/persistence/options.ts
+++ b/src/core/common/persistence/options.ts
@@ -1,4 +1,4 @@
 export type FindOptions = {
-  limit?: number;
-  offset?: number;
+  take?: number;
+  skip?: number;
 };

--- a/src/infrastructure/adapter/prisma/repository/Recipe.ts
+++ b/src/infrastructure/adapter/prisma/repository/Recipe.ts
@@ -8,14 +8,9 @@ export class RecipeRepository implements RecipePort {
   constructor(private readonly prisma: PrismaClient) {}
 
   public async getList(options?: FindOptions) {
-    const findOptions = {
-      skip: options?.offset,
-      take: options?.limit,
-    };
-
     const [recipes, count] = await this.prisma.$transaction([
-      this.prisma.recipe.findMany(findOptions),
-      this.prisma.recipe.count(findOptions),
+      this.prisma.recipe.findMany(options),
+      this.prisma.recipe.count(options),
     ]);
 
     return [recipes, count] as const;

--- a/src/infrastructure/adapter/prisma/repository/Recipe.ts
+++ b/src/infrastructure/adapter/prisma/repository/Recipe.ts
@@ -2,15 +2,23 @@ import { FindOptions } from '@core/common/persistence/options';
 import { RecipePort } from '@core/domain/ports/Recipe';
 import { Injectable } from '@nestjs/common';
 import { PrismaClient } from '../client/PrismaClient';
+import { ApiConfig } from '@infrastructure/config/Api';
+
+const DEFAULT_PAGE_SIZE = 50;
 
 @Injectable()
 export class RecipeRepository implements RecipePort {
   constructor(private readonly prisma: PrismaClient) {}
 
   public async getList(options?: FindOptions) {
+    const optionsWithDefaults = {
+      take: ApiConfig.DEFAULT_PAGE_SIZE || DEFAULT_PAGE_SIZE,
+      ...options,
+    };
+
     const [recipes, count] = await this.prisma.$transaction([
-      this.prisma.recipe.findMany(options),
-      this.prisma.recipe.count(options),
+      this.prisma.recipe.findMany(optionsWithDefaults),
+      this.prisma.recipe.count(optionsWithDefaults),
     ]);
 
     return [recipes, count] as const;

--- a/src/infrastructure/config/Api.ts
+++ b/src/infrastructure/config/Api.ts
@@ -17,4 +17,7 @@ export class ApiConfig {
 
   public static readonly THROTTLER_LIMIT?: number =
     get('THROTTLER_TTL').asInt();
+
+  public static readonly DEFAULT_PAGE_SIZE?: number =
+    get('DEFAULT_PAGE_SIZE').asInt();
 }


### PR DESCRIPTION
### Context

For now our `GET /recipes` endpoint didn't accept any query params to filter the results.

Let's start with a simple pagination feature.

### Content

We can simply forward the query parameters to the service, and then to the repository, as long as we validate the query shape with a validation pipe.