### PR TITLE
Expose recipe author

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,9 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { ignoreRestSiblings: true },
+    ],
   },
 };

--- a/src/core/domain/dto/recipe/RecipeDto.ts
+++ b/src/core/domain/dto/recipe/RecipeDto.ts
@@ -4,12 +4,23 @@ import { Recipe } from '@core/domain/entities/recipe';
 import { ApiProperty } from '@nestjs/swagger';
 import { plainToInstance } from 'class-transformer';
 
+class RecipeAuthorDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty({
+    description: "The name of the recipe's author",
+    example: 'Shackleton',
+  })
+  name: string;
+}
+
 export class RecipeDto {
   @ApiProperty()
   public id: number;
 
-  @ApiProperty()
-  public userId: number;
+  @ApiProperty({ type: RecipeAuthorDto })
+  public author: RecipeAuthorDto;
 
   @ApiProperty({
     required: false,
@@ -102,7 +113,11 @@ export class RecipeDto {
   public updatedAt: string;
 
   public static createFromRecipe(recipe: Recipe): RecipeDto {
-    const dto = plainToInstance(RecipeDto, recipe);
+    const { userId: _userId, ...recipeRest } = recipe;
+
+    const dto = plainToInstance(RecipeDto, recipeRest);
+
+    dto.author = recipe.user;
 
     return dto;
   }

--- a/src/core/domain/entities/recipe.ts
+++ b/src/core/domain/entities/recipe.ts
@@ -1,5 +1,6 @@
 import { RecipeType } from '../../common/enums/recipe-type';
 import { Season } from '../../common/enums/season';
+import { User } from './user';
 
 export class Recipe {
   id: number;
@@ -17,4 +18,5 @@ export class Recipe {
   type: `${RecipeType}`;
   createdAt: Date;
   updatedAt: Date;
+  user: Pick<User, 'id' | 'name'>;
 }

--- a/src/infrastructure/adapter/prisma/repository/Recipe.ts
+++ b/src/infrastructure/adapter/prisma/repository/Recipe.ts
@@ -11,14 +11,26 @@ export class RecipeRepository implements RecipePort {
   constructor(private readonly prisma: PrismaClient) {}
 
   public async getList(options?: FindOptions) {
-    const optionsWithDefaults = {
+    const commonOptionsWithDefaults = {
       take: ApiConfig.DEFAULT_PAGE_SIZE || DEFAULT_PAGE_SIZE,
       ...options,
     };
 
+    const findOptionsWithDefault = {
+      ...commonOptionsWithDefaults,
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    };
+
     const [recipes, count] = await this.prisma.$transaction([
-      this.prisma.recipe.findMany(optionsWithDefaults),
-      this.prisma.recipe.count(optionsWithDefaults),
+      this.prisma.recipe.findMany(findOptionsWithDefault),
+      this.prisma.recipe.count(commonOptionsWithDefaults),
     ]);
 
     return [recipes, count] as const;


### PR DESCRIPTION
### Context

For now we were returning plain recipes from the API with "userId" property.

This is not quite user friendly, instead we would like to expose an "author" fields which would include the recipe owner's name and id.

### Content

We can add joins / relations to prisma queries using the "include" field.

To return the proper field from our API, we also have to adjust our recipe DTOs.