### PR TITLE
Add User module base functionality

### DIFF
--- a/src/application/api/controllers/UserController.ts
+++ b/src/application/api/controllers/UserController.ts
@@ -1,0 +1,26 @@
+import {
+  Controller,
+  Get,
+  HttpStatus,
+  Inject,
+  Param,
+  ParseIntPipe,
+} from '@nestjs/common';
+import { ApiResponse } from '@nestjs/swagger';
+import { UserTokens } from '@core/domain/di/tokens/User';
+import { UserUseCases } from '@core/domain/usecases/User';
+import { UserDto } from '@core/domain/dto/user/UserDto';
+
+@Controller('users')
+export class UserController {
+  constructor(
+    @Inject(UserTokens.UserUseCase)
+    private readonly userUseCases: UserUseCases,
+  ) {}
+
+  @Get(':id')
+  @ApiResponse({ status: HttpStatus.OK, type: UserDto })
+  getUser(@Param('id', new ParseIntPipe()) id: number): Promise<UserDto> {
+    return this.userUseCases.get(id);
+  }
+}

--- a/src/application/modules/RootModule.ts
+++ b/src/application/modules/RootModule.ts
@@ -3,6 +3,7 @@ import { RecipeModule } from './RecipeModule';
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { UserModule } from './UserModule';
 
 const DEFAULT_THROTTLER_TTL = 600; // 10 minutes
 const DEFAULT_THROTTLER_LIMIT = 200;
@@ -10,6 +11,7 @@ const DEFAULT_THROTTLER_LIMIT = 200;
 @Module({
   imports: [
     RecipeModule,
+    UserModule,
     ThrottlerModule.forRoot({
       ttl: ApiConfig.THROTTLER_TTL || DEFAULT_THROTTLER_TTL,
       limit: ApiConfig.THROTTLER_LIMIT || DEFAULT_THROTTLER_LIMIT,

--- a/src/application/modules/UserModule.ts
+++ b/src/application/modules/UserModule.ts
@@ -1,0 +1,16 @@
+import { UserService } from '@core/services/User';
+import { Module } from '@nestjs/common';
+import { UserRepository } from '@infrastructure/adapter/prisma/repository/User';
+import { UserTokens } from '@core/domain/di/tokens/User';
+import { PrismaClient } from '@infrastructure/adapter/prisma/client/PrismaClient';
+import { UserController } from '@application/api/controllers/UserController';
+
+@Module({
+  controllers: [UserController],
+  providers: [
+    PrismaClient,
+    { provide: UserTokens.UserPort, useClass: UserRepository },
+    { provide: UserTokens.UserUseCase, useClass: UserService },
+  ],
+})
+export class UserModule {}

--- a/src/core/common/ports/GenericPort.ts
+++ b/src/core/common/ports/GenericPort.ts
@@ -3,11 +3,11 @@ import { ListOptions } from '../persistence/ListOptions';
 export interface GenericPort<T> {
   getList?(options?: ListOptions): Promise<readonly [T[], number]>;
 
-  get?(id: string): Promise<T>;
+  get?(id: number): Promise<T | null>;
 
   create?(item: T): Promise<T>;
 
-  update?(id: string, item: T): Promise<T>;
+  update?(id: number, item: T): Promise<T>;
 
-  delete?(id: string): Promise<T>;
+  delete?(id: number): Promise<T>;
 }

--- a/src/core/common/usecases/GenericUseCases.ts
+++ b/src/core/common/usecases/GenericUseCases.ts
@@ -4,11 +4,11 @@ import { ListOptions } from '../persistence/ListOptions';
 export interface GenericUseCases<T> {
   getList?(options?: ListOptions): Promise<List<T>>;
 
-  get?(id: string): Promise<T>;
+  get?(id: number): Promise<T>;
 
   create?(item: T): Promise<T>;
 
-  update?(id: string, item: T): Promise<T>;
+  update?(id: number, item: T): Promise<T>;
 
-  delete?(id: string): Promise<T>;
+  delete?(id: number): Promise<T>;
 }

--- a/src/core/common/utils/assert/CoreAssert.ts
+++ b/src/core/common/utils/assert/CoreAssert.ts
@@ -1,0 +1,9 @@
+export class CoreAssert {
+  public static notEmpty<T>(value: T | null | undefined, exception: Error): T {
+    if (value === null || value === undefined) {
+      throw exception;
+    }
+
+    return value;
+  }
+}

--- a/src/core/domain/di/tokens/User.ts
+++ b/src/core/domain/di/tokens/User.ts
@@ -1,0 +1,4 @@
+export enum UserTokens {
+  UserUseCase = 'USER_USE_CASE',
+  UserPort = 'USER_PORT',
+}

--- a/src/core/domain/dto/user/UserDto.ts
+++ b/src/core/domain/dto/user/UserDto.ts
@@ -1,0 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { plainToInstance, Exclude } from 'class-transformer';
+import { RecipeDto } from '../recipe/RecipeDto';
+import { Role } from '@core/common/enums/Role';
+import { User } from '@core/domain/entities/User';
+
+export class UserDto {
+  @ApiProperty()
+  public id: number;
+
+  @Exclude()
+  public email: string;
+
+  @Exclude()
+  public password: string;
+
+  @Exclude()
+  public roles: `${Role}`[];
+
+  @ApiProperty({
+    description: 'The recipes authored by this user.',
+    type: [RecipeDto],
+  })
+  public recipes?: RecipeDto[];
+
+  @ApiProperty()
+  public createdAt: string;
+
+  @ApiProperty()
+  public updatedAt: string;
+
+  public static createFromUser(user: User): UserDto {
+    const dto = plainToInstance(UserDto, user);
+
+    dto.createdAt = user.createdAt.toISOString();
+    dto.updatedAt = user.updatedAt.toISOString();
+
+    return dto;
+  }
+
+  public static createListFromUsers(users: User[]): UserDto[] {
+    return users.map(this.createFromUser);
+  }
+}

--- a/src/core/domain/entities/User.ts
+++ b/src/core/domain/entities/User.ts
@@ -7,9 +7,9 @@ export class User {
   email: string;
   name: string;
   password: string;
-  recipes: Recipe[];
-  roles: Role[];
-  refreshTokens: RefreshToken[];
-  createdAt: string;
-  updatedAt: string;
+  recipes?: Recipe[];
+  roles: `${Role}`[];
+  refreshTokens?: RefreshToken[];
+  createdAt: Date;
+  updatedAt: Date;
 }

--- a/src/core/domain/ports/User.ts
+++ b/src/core/domain/ports/User.ts
@@ -1,0 +1,6 @@
+import { GenericPort } from '@core/common/ports/GenericPort';
+import { User } from '../entities/User';
+
+export interface UserPort extends GenericPort<User> {
+  get(id: number): Promise<User | null>;
+}

--- a/src/core/domain/usecases/User.ts
+++ b/src/core/domain/usecases/User.ts
@@ -1,0 +1,6 @@
+import { GenericUseCases } from '@core/common/usecases/GenericUseCases';
+import { UserDto } from '../dto/user/UserDto';
+
+export interface UserUseCases extends GenericUseCases<UserDto> {
+  get(id: number): Promise<UserDto>;
+}

--- a/src/core/services/User.ts
+++ b/src/core/services/User.ts
@@ -1,0 +1,24 @@
+import { CoreAssert } from '@core/common/utils/assert/CoreAssert';
+import { UserTokens } from '@core/domain/di/tokens/User';
+import { UserDto } from '@core/domain/dto/user/UserDto';
+import { UserPort } from '@core/domain/ports/User';
+import { UserUseCases } from '@core/domain/usecases/User';
+import { NotFoundException, Inject, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class UserService implements UserUseCases {
+  constructor(
+    @Inject(UserTokens.UserPort)
+    private readonly userPort: UserPort,
+  ) {}
+
+  async get(id: number): Promise<UserDto> {
+    const user = CoreAssert.notEmpty(
+      await this.userPort.get(id),
+      // TODO: create more abstract exception class and use nest's exception filter
+      new NotFoundException(),
+    );
+
+    return UserDto.createFromUser(user);
+  }
+}

--- a/src/infrastructure/adapter/prisma/repository/User.ts
+++ b/src/infrastructure/adapter/prisma/repository/User.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaClient } from '../client/PrismaClient';
+import { UserPort } from '@core/domain/ports/User';
+
+@Injectable()
+export class UserRepository implements UserPort {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async get(id: number) {
+    const user = await this.prisma.user.findUnique({
+      where: {
+        id,
+      },
+    });
+
+    return user;
+  }
+}

--- a/test/e2e/recipes/recipes.spec.ts
+++ b/test/e2e/recipes/recipes.spec.ts
@@ -7,6 +7,7 @@ import { clearDb } from '@test/utils/clearDb';
 import { RecipeDto } from '@core/domain/dto/recipe/RecipeDto';
 import { Recipe } from '@core/domain/entities/Recipe';
 import { instanceToPlain } from 'class-transformer';
+import { orderItems } from '@test/utils/orderItems';
 
 describe('Recipes', () => {
   let testServer: TestServer;
@@ -38,11 +39,15 @@ describe('Recipes', () => {
     });
 
     it('should return a list of recipes', () => {
+      const data = instanceToPlain<RecipeDto[]>(
+        RecipeDto.createListFromRecipes(recipes),
+      ) as RecipeDto[];
+
       return supertest(testServer.serverApplication.getHttpServer())
         .get('/recipes')
         .expect(200)
         .expect({
-          data: instanceToPlain(RecipeDto.createListFromRecipes(recipes)),
+          data: orderItems(data),
           count: 2,
         });
     });

--- a/test/e2e/users/users.spec.ts
+++ b/test/e2e/users/users.spec.ts
@@ -1,0 +1,69 @@
+import * as supertest from 'supertest';
+import { TestServer } from '@test/utils/TestServer';
+import { prismaClient } from '@test/utils/prismaClient';
+import { UserFixture } from '../fixtures/UserFixture';
+import { clearDb } from '@test/utils/clearDb';
+import { instanceToPlain } from 'class-transformer';
+import { User } from '@core/domain/entities/User';
+import { UserDto } from '@core/domain/dto/user/UserDto';
+
+describe('Recipes', () => {
+  let testServer: TestServer;
+  let userFixture: UserFixture;
+
+  beforeAll(async () => {
+    testServer = await TestServer.create();
+
+    userFixture = UserFixture.create(prismaClient);
+
+    await testServer.serverApplication.init();
+  });
+
+  afterAll(async () => {
+    if (testServer) {
+      await testServer.serverApplication.close();
+    }
+  });
+
+  describe('GET /users/:id', () => {
+    let user: User;
+
+    beforeAll(async () => {
+      await clearDb();
+
+      user = await userFixture.insertOne({
+        name: 'John',
+        email: 'john@smith.com',
+        password: '1234',
+        roles: ['ADMIN'],
+      });
+    });
+
+    it('should return only exposed user fields', () => {
+      return supertest(testServer.serverApplication.getHttpServer())
+        .get(`/users/${user.id}`)
+        .expect(200)
+        .expect((response) => {
+          expect(response.body.email).toBeUndefined();
+          expect(response.body.password).toBeUndefined();
+          expect(response.body.roles).toBeUndefined();
+
+          expect(response.body).toEqual(
+            instanceToPlain(UserDto.createFromUser(user)),
+          );
+        });
+    });
+
+    it('should return a 404 error if user does not exist', () => {
+      return supertest(testServer.serverApplication.getHttpServer())
+        .get(`/users/9999`)
+        .expect(404);
+    });
+
+    it('should return a 400 error if id is invalid', () => {
+      return supertest(testServer.serverApplication.getHttpServer())
+        .get(`/users/abcd`)
+        .expect(400);
+    });
+  });
+});

--- a/test/utils/orderItems.ts
+++ b/test/utils/orderItems.ts
@@ -1,0 +1,8 @@
+type Sorter<T> = (a: T, b: T) => number;
+
+const defaultSorter: Sorter<{ id: number }> = (a, b) => b.id - a.id;
+
+export const orderItems = <T extends { id: number }>(
+  items: T[],
+  sorter: Sorter<T> = defaultSorter,
+) => items.sort(sorter);


### PR DESCRIPTION
The other main entity besides recipe is users. I'm not sure yet if we should expose them as "authors" instead of "users".

For now we are creating the base module and interfaces as well as exposing the `GET /users/:id` endpoint.

The main purpose is to be able to implement our authentication and authorization logic on top of users.