### PR TITLE
Store jti claim instead of refresh tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ lerna-debug.log*
 env/development.env
 env/test.env
 env/postgres.env
+env/docker-compose.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       dockerfile: Dockerfile.dev
     depends_on:
       - meny-db
-    env_file: env/development.env
+    env_file: env/docker-compose.env
     environment:
       - NODE_ENV=${NODE_ENV:-development}
     ports:

--- a/env/development.example.env
+++ b/env/development.example.env
@@ -3,4 +3,4 @@ API_VERSION=0.1
 
 DEFAULT_PAGE_SIZE=50
 
-DATABASE_URL="postgresql://postgres:postgres@meny-db:5432/meny?schema=meny&connect_timeout=300"
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/meny?schema=meny&connect_timeout=300"

--- a/env/docker-compose.example.env
+++ b/env/docker-compose.example.env
@@ -1,0 +1,6 @@
+PORT=3000
+API_VERSION=0.1
+
+DEFAULT_PAGE_SIZE=50
+
+DATABASE_URL="postgresql://postgres:postgres@meny-db:5432/meny?schema=meny&connect_timeout=300"

--- a/src/infrastructure/adapter/prisma/schema/migrations/20230417094739_refresh_token_jti/migration.sql
+++ b/src/infrastructure/adapter/prisma/schema/migrations/20230417094739_refresh_token_jti/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `token` on the `RefreshToken` table. All the data in the column will be lost.
+  - Added the required column `jti` to the `RefreshToken` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "RefreshToken" DROP COLUMN "token",
+ADD COLUMN     "jti" TEXT NOT NULL;

--- a/src/infrastructure/adapter/prisma/schema/schema.prisma
+++ b/src/infrastructure/adapter/prisma/schema/schema.prisma
@@ -17,7 +17,7 @@ model RefreshToken {
   id        Int      @id @default(autoincrement())
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId    Int
-  token     String
+  jti       String
   family    String   @unique
   expiresAt DateTime
   createdAt DateTime @default(now())


### PR DESCRIPTION
### Context

We will make use of a refresh token rotation, and as such we need a way to reference refresh token from storage in order to invalidate them.

Instead of storing the tokens themselves, we can instead store a unique identifier that we will attach to the refresh tokens as a "jti" claim, this will be enough to uniquely identify the tokens.

### Content

Adding the migration to change the RefreshToken schema, and splitting env files between docker-compose and local to make it easier to work in both environments.