### PR TITLE
Update RefreshToken entity with jti property

### DIFF
--- a/src/core/domain/entities/RefreshToken.ts
+++ b/src/core/domain/entities/RefreshToken.ts
@@ -1,7 +1,7 @@
 export class RefreshToken {
   id: number;
   userId: number;
-  token: string;
+  jti: string;
   family: string;
   expiresAt: string;
   createdAt: string;


### PR DESCRIPTION
### Context

We recently adjusted our database schema to use a "jti" column over "token" column for refresh tokens.

The domain entity wasn't updated to reflect this, which is an indication that it is not yet actually used 😉 

### Content

We are updating the domain entity to match our db schema. In theory it should trickle down the other way around, but we have purposefully used an abstraction heavy architecture from the beginning in this project, if only for experiencing its resilience to change.