### PR TITLE
Add recipe crud functionality

### DIFF
--- a/src/application/api/controllers/RecipeController.ts
+++ b/src/application/api/controllers/RecipeController.ts
@@ -1,9 +1,17 @@
 import {
+  Body,
   Controller,
+  Delete,
   Get,
   HttpStatus,
   Inject,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
   Query,
+  Req,
+  UseGuards,
   ValidationPipe,
 } from '@nestjs/common';
 import { RecipeUseCases } from '@core/domain/usecases/Recipe';
@@ -12,6 +20,12 @@ import { ApiResponse } from '@nestjs/swagger';
 import { RecipeDtoList } from '@core/domain/dto/recipe/RecipeDtoList';
 import { ListOptionsQueryDto } from '@core/common/dto/ListOptionsQueryDto';
 import { PipeConfig } from './config/Pipe';
+import { RecipeDto } from '@core/domain/dto/recipe/RecipeDto';
+import { UpsertRecipeDto } from '@core/domain/dto/recipe/UpsertRecipeDto';
+import { RequestWithUser } from '@application/types/auth';
+import { Roles } from '../decorators/Roles';
+import { Role } from '@core/common/enums/Role';
+import { RecipeOwnerGuard } from '../guards/RecipeOwnerGuard';
 
 @Controller('recipes')
 export class RecipeController {
@@ -27,5 +41,34 @@ export class RecipeController {
     query: ListOptionsQueryDto,
   ): Promise<RecipeDtoList> {
     return this.recipeUseCases.getList(query);
+  }
+
+  @Post()
+  @Roles(Role.Author)
+  @ApiResponse({ status: HttpStatus.CREATED, type: RecipeDto })
+  createRecipe(
+    @Body(new ValidationPipe(PipeConfig.bodyValidation)) body: UpsertRecipeDto,
+    @Req() request: RequestWithUser,
+  ) {
+    return this.recipeUseCases.create(body, request.user);
+  }
+
+  @Patch(':id')
+  @UseGuards(RecipeOwnerGuard)
+  @Roles(Role.Author)
+  @ApiResponse({ status: HttpStatus.OK, type: RecipeDto })
+  updateRecipe(
+    @Body(new ValidationPipe(PipeConfig.bodyValidation)) body: UpsertRecipeDto,
+    @Param('id', new ParseIntPipe()) id: number,
+  ) {
+    return this.recipeUseCases.update(body, id);
+  }
+
+  @Delete(':id')
+  @UseGuards(RecipeOwnerGuard)
+  @Roles(Role.Author)
+  @ApiResponse({ status: HttpStatus.OK, type: RecipeDto })
+  deleteRecipe(@Param('id', new ParseIntPipe()) id: number) {
+    return this.recipeUseCases.delete(id);
   }
 }

--- a/src/application/api/controllers/UserController.ts
+++ b/src/application/api/controllers/UserController.ts
@@ -14,6 +14,7 @@ import { UserTokens } from '@core/domain/di/tokens/User';
 import { UserUseCases } from '@core/domain/usecases/User';
 import { UserDto } from '@core/domain/dto/user/UserDto';
 import { CreateUserDto } from '@core/domain/dto/user/CreateUserDto';
+import { PipeConfig } from './config/Pipe';
 
 @Controller('users')
 export class UserController {
@@ -31,7 +32,8 @@ export class UserController {
   @Post()
   @ApiResponse({ status: HttpStatus.CREATED, type: UserDto })
   createUser(
-    @Body(new ValidationPipe()) { email, password, name }: CreateUserDto,
+    @Body(new ValidationPipe(PipeConfig.bodyValidation))
+    { email, password, name }: CreateUserDto,
   ) {
     return this.userUseCases.create({ email, password, name });
   }

--- a/src/application/api/controllers/config/Pipe.ts
+++ b/src/application/api/controllers/config/Pipe.ts
@@ -7,4 +7,13 @@ export class PipeConfig {
       enableImplicitConversion: true,
     },
   };
+
+  public static readonly bodyValidation = {
+    whitelist: true,
+    forbidNonWhitelisted: true,
+    transform: true,
+    transformOptions: {
+      enableImplicitConversion: true,
+    },
+  };
 }

--- a/src/application/api/decorators/Roles.ts
+++ b/src/application/api/decorators/Roles.ts
@@ -1,0 +1,7 @@
+import { SetMetadata, UseGuards, applyDecorators } from '@nestjs/common';
+import { Role } from '@core/common/enums/Role';
+import { RoleGuard } from '../guards/RoleGuard';
+import { AuthGuard } from '../guards/AuthGuard';
+
+export const Roles = (...roles: Role[]) =>
+  applyDecorators(SetMetadata('roles', roles), UseGuards(AuthGuard, RoleGuard));

--- a/src/application/api/guards/AuthGuard.ts
+++ b/src/application/api/guards/AuthGuard.ts
@@ -1,0 +1,64 @@
+import { RequestWithUser } from '@application/types/auth';
+import { CoreAssert } from '@core/common/utils/assert/CoreAssert';
+import { UserTokens } from '@core/domain/di/tokens/User';
+import { UserPort } from '@core/domain/ports/User';
+import { AccessTokenPayload } from '@core/domain/types/auth';
+import { AuthConfig } from '@infrastructure/config/Auth';
+import {
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(
+    private jwtService: JwtService,
+    @Inject(UserTokens.UserPort)
+    private readonly userPort: UserPort,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request: RequestWithUser = context.switchToHttp().getRequest();
+
+    const token = this.extractTokenFromHeader(request);
+
+    if (!token) {
+      throw new UnauthorizedException();
+    }
+
+    let payload: AccessTokenPayload;
+
+    try {
+      payload = await this.jwtService.verifyAsync<AccessTokenPayload>(
+        token,
+        AuthConfig.accessToken,
+      );
+    } catch {
+      throw new UnauthorizedException('Invalid Access Token');
+    }
+
+    const user = CoreAssert.notEmpty(
+      await this.userPort.get({ id: payload.sub }),
+      new UnauthorizedException(),
+    );
+
+    request.user = {
+      id: user.id,
+      roles: user.roles,
+      name: user.name,
+      email: user.email,
+    };
+
+    return true;
+  }
+
+  private extractTokenFromHeader(request: RequestWithUser): string | undefined {
+    const [type, token] = request.headers.authorization?.split(' ') ?? [];
+
+    return type === 'Bearer' ? token : undefined;
+  }
+}

--- a/src/application/api/guards/RecipeOwnerGuard.ts
+++ b/src/application/api/guards/RecipeOwnerGuard.ts
@@ -1,0 +1,41 @@
+import { RequestWithUser } from '@application/types/auth';
+import { CoreAssert } from '@core/common/utils/assert/CoreAssert';
+import { RecipeTokens } from '@core/domain/di/tokens/Recipe';
+import { RecipePort } from '@core/domain/ports/Recipe';
+import {
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+
+@Injectable()
+export class RecipeOwnerGuard implements CanActivate {
+  constructor(
+    @Inject(RecipeTokens.RecipePort)
+    private readonly recipePort: RecipePort,
+  ) {}
+
+  public async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request: RequestWithUser = context.switchToHttp().getRequest();
+
+    const recipeId = Number(request.params.id);
+
+    const recipe = CoreAssert.notEmpty(
+      await this.recipePort.get({ id: recipeId }),
+      new NotFoundException(),
+    );
+
+    const isAdmin = request.user.roles.includes('ADMIN');
+
+    const isOwner = recipe.userId === request.user.id;
+
+    if (isAdmin || isOwner) {
+      return true;
+    }
+
+    throw new UnauthorizedException('User does not own this recipe.');
+  }
+}

--- a/src/application/api/guards/RoleGuard.ts
+++ b/src/application/api/guards/RoleGuard.ts
@@ -1,0 +1,33 @@
+import { RequestWithUser } from '@application/types/auth';
+import { Role } from '@core/common/enums/Role';
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+@Injectable()
+export class RoleGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  public async canActivate(context: ExecutionContext): Promise<boolean> {
+    const roles =
+      this.reflector.get<Role[]>('roles', context.getHandler()) || [];
+
+    const request: RequestWithUser = context.switchToHttp().getRequest();
+
+    const isAdmin = request.user.roles.includes('ADMIN');
+
+    const hasRole = roles.find((role) => request.user.roles.includes(role));
+
+    if (isAdmin || hasRole) {
+      return true;
+    }
+
+    throw new UnauthorizedException(
+      'User does not have the necessary role to perform this request.',
+    );
+  }
+}

--- a/src/application/modules/AuthModule.ts
+++ b/src/application/modules/AuthModule.ts
@@ -10,7 +10,11 @@ import { PrismaClient } from '@infrastructure/adapter/prisma/client/PrismaClient
 import { AuthTokens } from '@core/domain/di/tokens/Auth';
 
 @Module({
-  imports: [JwtModule.register({})],
+  imports: [
+    JwtModule.register({
+      global: true,
+    }),
+  ],
   providers: [
     Logger,
     PrismaClient,

--- a/src/application/modules/RecipeModule.ts
+++ b/src/application/modules/RecipeModule.ts
@@ -4,11 +4,14 @@ import { Module } from '@nestjs/common';
 import { RecipeRepository } from '@infrastructure/adapter/prisma/repository/Recipe';
 import { RecipeTokens } from '@core/domain/di/tokens/Recipe';
 import { PrismaClient } from '@infrastructure/adapter/prisma/client/PrismaClient';
+import { UserTokens } from '@core/domain/di/tokens/User';
+import { UserRepository } from '@infrastructure/adapter/prisma/repository/User';
 
 @Module({
   controllers: [RecipeController],
   providers: [
     PrismaClient,
+    { provide: UserTokens.UserPort, useClass: UserRepository },
     { provide: RecipeTokens.RecipePort, useClass: RecipeRepository },
     { provide: RecipeTokens.RecipeUseCase, useClass: RecipeService },
   ],

--- a/src/application/types/auth.ts
+++ b/src/application/types/auth.ts
@@ -1,6 +1,6 @@
-import { User } from '@core/domain/entities/User';
+import { ContextUser } from '@core/domain/entities/User';
 import { Request } from 'express';
 
 export type RequestWithUser = Request & {
-  user: Pick<User, 'id' | 'email' | 'roles' | 'name'>;
+  user: ContextUser;
 };

--- a/src/core/common/ports/GenericPort.ts
+++ b/src/core/common/ports/GenericPort.ts
@@ -1,14 +1,15 @@
 import { ListOptions } from '../persistence/ListOptions';
 import { DeleteManyOptions } from '../persistence/DeleteManyOptions';
+import { ContextUser } from '@core/domain/entities/User';
 
 export interface GenericPort<T> {
   getList?(options?: ListOptions<T>): Promise<readonly [T[], number]>;
 
   get?(options: Partial<Pick<T, keyof T>>): Promise<T | null>;
 
-  create?(item: Partial<T>): Promise<T>;
+  create?(item: Partial<T>, user?: ContextUser): Promise<T>;
 
-  update?(id: number, item: T): Promise<T>;
+  update?(item: Partial<T>, id: number): Promise<T>;
 
   delete?(id: number): Promise<T>;
 

--- a/src/core/common/usecases/GenericUseCases.ts
+++ b/src/core/common/usecases/GenericUseCases.ts
@@ -1,3 +1,4 @@
+import { ContextUser } from '@core/domain/entities/User';
 import { List } from '../dto/List';
 import { ListOptions } from '../dto/ListOptions';
 
@@ -6,9 +7,9 @@ export interface GenericUseCases<T> {
 
   get?(id: number): Promise<T>;
 
-  create?(item: Partial<T>): Promise<T>;
+  create?(item: Partial<T>, user?: ContextUser): Promise<T>;
 
-  update?(id: number, item: T): Promise<T>;
+  update?(item: Partial<T>, id: number): Promise<T>;
 
   delete?(id: number): Promise<T>;
 }

--- a/src/core/domain/dto/recipe/RecipeDto.ts
+++ b/src/core/domain/dto/recipe/RecipeDto.ts
@@ -106,6 +106,14 @@ export class RecipeDto {
   })
   public type: `${RecipeType}`;
 
+  @ApiProperty({
+    required: false,
+    example: true,
+    default: false,
+    description: 'Is the recipe visible to others.',
+  })
+  public visible: boolean;
+
   @ApiProperty()
   public createdAt: string;
 

--- a/src/core/domain/dto/recipe/UpsertRecipeDto.ts
+++ b/src/core/domain/dto/recipe/UpsertRecipeDto.ts
@@ -1,0 +1,133 @@
+import { RecipeType } from '@core/common/enums/RecipeType';
+import { Season } from '@core/common/enums/Season';
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  IsOptional,
+  IsInt,
+  IsEnum,
+  IsArray,
+  IsBoolean,
+} from 'class-validator';
+
+export class UpsertRecipeDto {
+  @ApiProperty({
+    required: false,
+    example: 'Cassoulet',
+    description: 'The name of the recipe',
+  })
+  @IsString()
+  @IsOptional()
+  public name?: string | null;
+
+  @ApiProperty({
+    required: false,
+    example: 15,
+    description:
+      'The cooking time for the recipe in minutes. This is a general indicator and it should be specified further in the recipe steps.',
+  })
+  @IsInt()
+  @IsOptional()
+  public cooking?: number | null;
+
+  @ApiProperty({
+    required: false,
+    example: 'An alternative is to use Rice instead of Pasta.',
+    description: 'An additional note about the recipe.',
+  })
+  @IsString()
+  @IsOptional()
+  public note?: string | null;
+
+  @ApiProperty({
+    required: false,
+    example: 'A delicious and comforting winter dish.',
+    description: 'The main description of the recipe.',
+  })
+  @IsString()
+  @IsOptional()
+  public description?: string | null;
+
+  @ApiProperty({
+    required: false,
+    example: 20,
+    description:
+      'The preparation time necessary for the recipe in minutes. This is a general indicator and it should be specified further in the recipe steps.',
+  })
+  @IsInt()
+  @IsOptional()
+  public preparation?: number | null;
+
+  @ApiProperty({
+    required: false,
+    example: 2000,
+    description: 'The average cost of the ingredients for the recipe in cents.',
+  })
+  @IsInt()
+  @IsOptional()
+  public price?: number | null;
+
+  @ApiProperty({
+    required: false,
+    example: 2,
+    description:
+      'The expected number of servings with the provided ingredients.',
+  })
+  @IsInt()
+  @IsOptional()
+  public servings?: number | null;
+
+  @ApiProperty({
+    required: false,
+    example: Season.Winter,
+    default: Season.Unspecified,
+    enum: Season,
+    description: 'The best season to find fresh ingredients for this recipe.',
+  })
+  @IsEnum(Season)
+  @IsOptional()
+  public season?: `${Season}`;
+
+  @ApiProperty({
+    required: false,
+    type: [String],
+    example: ['Salt', 'Flour', 'Water'],
+    description: 'The ingredients necessary to prepare the recipe.',
+  })
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  public ingredients?: string[];
+
+  @ApiProperty({
+    required: false,
+    type: [String],
+    example: ['Cut the vegetables', '???', 'Profit'],
+    description: 'The steps to follow in order to prepare the recipe.',
+  })
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  public steps?: string[];
+
+  @ApiProperty({
+    required: false,
+    example: RecipeType.Main,
+    default: RecipeType.Unspecified,
+    enum: RecipeType,
+    description: 'The type of recipe.',
+  })
+  @IsEnum(RecipeType)
+  @IsOptional()
+  public type?: `${RecipeType}`;
+
+  @ApiProperty({
+    required: false,
+    example: true,
+    default: false,
+    description: 'Is the recipe visible to others.',
+  })
+  @IsBoolean()
+  @IsOptional()
+  public visible?: boolean;
+}

--- a/src/core/domain/entities/Recipe.ts
+++ b/src/core/domain/entities/Recipe.ts
@@ -19,4 +19,5 @@ export class Recipe {
   createdAt: Date;
   updatedAt: Date;
   user: Pick<User, 'id' | 'name'>;
+  visible: boolean;
 }

--- a/src/core/domain/entities/User.ts
+++ b/src/core/domain/entities/User.ts
@@ -13,3 +13,5 @@ export class User {
   createdAt: Date;
   updatedAt: Date;
 }
+
+export type ContextUser = Pick<User, 'id' | 'email' | 'roles' | 'name'>;

--- a/src/core/domain/ports/Recipe.ts
+++ b/src/core/domain/ports/Recipe.ts
@@ -1,11 +1,21 @@
 import { GenericPort } from '@core/common/ports/GenericPort';
 import { Recipe } from '../entities/Recipe';
 import { ListOptions } from '@core/common/persistence/ListOptions';
+import { UpsertRecipeDto } from '../dto/recipe/UpsertRecipeDto';
+import { ContextUser } from '../entities/User';
+
 export type GetRecipeOptions = Partial<Pick<Recipe, 'id'>>;
 
+export type UpsertRecipeOptions = UpsertRecipeDto;
 
 export interface RecipePort extends GenericPort<Recipe> {
   get(options: GetRecipeOptions): Promise<Recipe | null>;
 
   getList(options?: ListOptions<Recipe>): Promise<readonly [Recipe[], number]>;
+
+  create(options: UpsertRecipeOptions, user: ContextUser): Promise<Recipe>;
+
+  update(options: UpsertRecipeOptions, id: number): Promise<Recipe>;
+
+  delete(id: number): Promise<Recipe>;
 }

--- a/src/core/domain/ports/Recipe.ts
+++ b/src/core/domain/ports/Recipe.ts
@@ -1,7 +1,11 @@
 import { GenericPort } from '@core/common/ports/GenericPort';
 import { Recipe } from '../entities/Recipe';
 import { ListOptions } from '@core/common/persistence/ListOptions';
+export type GetRecipeOptions = Partial<Pick<Recipe, 'id'>>;
+
 
 export interface RecipePort extends GenericPort<Recipe> {
+  get(options: GetRecipeOptions): Promise<Recipe | null>;
+
   getList(options?: ListOptions<Recipe>): Promise<readonly [Recipe[], number]>;
 }

--- a/src/core/domain/types/auth.ts
+++ b/src/core/domain/types/auth.ts
@@ -1,5 +1,12 @@
+import { Role } from '@core/common/enums/Role';
+
 export type RefreshTokenPayload = {
   sub: number;
   jti: string;
   family: string;
+};
+
+export type AccessTokenPayload = {
+  sub: number;
+  roles: `${Role}`[];
 };

--- a/src/core/domain/usecases/Recipe.ts
+++ b/src/core/domain/usecases/Recipe.ts
@@ -2,7 +2,15 @@ import { GenericUseCases } from '@core/common/usecases/GenericUseCases';
 import { ListOptions } from '@core/common/dto/ListOptions';
 import { RecipeDtoList } from '../dto/recipe/RecipeDtoList';
 import { RecipeDto } from '../dto/recipe/RecipeDto';
+import { UpsertRecipeDto } from '../dto/recipe/UpsertRecipeDto';
+import { ContextUser } from '../entities/User';
 
 export interface RecipeUseCases extends GenericUseCases<RecipeDto> {
   getList(options?: ListOptions): Promise<RecipeDtoList>;
+
+  create(payload: UpsertRecipeDto, user: ContextUser): Promise<RecipeDto>;
+
+  update(payload: UpsertRecipeDto, id: number): Promise<RecipeDto>;
+
+  delete(id: number): Promise<RecipeDto>;
 }

--- a/src/core/services/Auth.ts
+++ b/src/core/services/Auth.ts
@@ -84,7 +84,7 @@ export class AuthService implements AuthUseCases {
     return user.roles;
   }
 
-  private async generateAccessToken(payload: {
+  private async createAccessToken(payload: {
     sub: number;
     roles: `${Role}`[];
   }): Promise<string> {
@@ -190,7 +190,7 @@ export class AuthService implements AuthUseCases {
 
     const roles = await this.getUserRoles(payload.sub);
 
-    const accessToken = await this.generateAccessToken({
+    const accessToken = await this.createAccessToken({
       sub: payload.sub,
       roles,
     });
@@ -209,7 +209,7 @@ export class AuthService implements AuthUseCases {
 
     const payload = { sub: user.id, roles: user.roles };
 
-    const accessToken = await this.generateAccessToken(payload);
+    const accessToken = await this.createAccessToken(payload);
 
     const refreshToken = await this.createRefreshToken({ sub: payload.sub });
 

--- a/src/core/services/Recipe.ts
+++ b/src/core/services/Recipe.ts
@@ -1,7 +1,9 @@
 import { ListOptions } from '@core/common/dto/ListOptions';
 import { RecipeTokens } from '@core/domain/di/tokens/Recipe';
+import { UpsertRecipeDto } from '@core/domain/dto/recipe/UpsertRecipeDto';
 import { RecipeDto } from '@core/domain/dto/recipe/RecipeDto';
 import { RecipeDtoList } from '@core/domain/dto/recipe/RecipeDtoList';
+import { ContextUser } from '@core/domain/entities/User';
 import { RecipePort } from '@core/domain/ports/Recipe';
 import { RecipeUseCases } from '@core/domain/usecases/Recipe';
 import { Inject, Injectable } from '@nestjs/common';
@@ -20,5 +22,29 @@ export class RecipeService implements RecipeUseCases {
       data: RecipeDto.createListFromRecipes(recipes),
       count,
     };
+  }
+
+  public async create(
+    payload: UpsertRecipeDto,
+    user: ContextUser,
+  ): Promise<RecipeDto> {
+    const recipe = await this.recipePort.create(payload, user);
+
+    return RecipeDto.createFromRecipe(recipe);
+  }
+
+  public async update(
+    payload: UpsertRecipeDto,
+    id: number,
+  ): Promise<RecipeDto> {
+    const recipe = await this.recipePort.update(payload, id);
+
+    return RecipeDto.createFromRecipe(recipe);
+  }
+
+  public async delete(id: number): Promise<RecipeDto> {
+    const recipe = await this.recipePort.delete(id);
+
+    return RecipeDto.createFromRecipe(recipe);
   }
 }

--- a/src/infrastructure/adapter/prisma/repository/Recipe.ts
+++ b/src/infrastructure/adapter/prisma/repository/Recipe.ts
@@ -1,5 +1,8 @@
 import { ListOptions } from '@core/common/persistence/ListOptions';
-import { RecipePort } from '@core/domain/ports/Recipe';
+import {
+  GetRecipeOptions,
+  RecipePort,
+} from '@core/domain/ports/Recipe';
 import { Injectable } from '@nestjs/common';
 import { PrismaClient } from '../client/PrismaClient';
 import { ApiConfig } from '@infrastructure/config/Api';
@@ -10,6 +13,22 @@ const DEFAULT_PAGE_SIZE = 50;
 @Injectable()
 export class RecipeRepository implements RecipePort {
   constructor(private readonly prisma: PrismaClient) {}
+
+  public async get(options: GetRecipeOptions) {
+    const recipe = await this.prisma.recipe.findUnique({
+      where: options,
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    return recipe;
+  }
 
   public async getList(
     options?: ListOptions<Recipe>,

--- a/src/infrastructure/adapter/prisma/repository/Recipe.ts
+++ b/src/infrastructure/adapter/prisma/repository/Recipe.ts
@@ -1,5 +1,6 @@
 import { ListOptions } from '@core/common/persistence/ListOptions';
 import {
+  UpsertRecipeOptions,
   GetRecipeOptions,
   RecipePort,
 } from '@core/domain/ports/Recipe';
@@ -7,6 +8,7 @@ import { Injectable } from '@nestjs/common';
 import { PrismaClient } from '../client/PrismaClient';
 import { ApiConfig } from '@infrastructure/config/Api';
 import { Recipe } from '@core/domain/entities/Recipe';
+import { ContextUser } from '@core/domain/entities/User';
 
 const DEFAULT_PAGE_SIZE = 50;
 
@@ -61,5 +63,54 @@ export class RecipeRepository implements RecipePort {
     ]);
 
     return [recipes, count] as const;
+  }
+
+  public async create(options: UpsertRecipeOptions, user: ContextUser) {
+    const persistedRecipe = await this.prisma.recipe.create({
+      data: { ...options, userId: user.id },
+    });
+
+    const recipe: Recipe = {
+      ...persistedRecipe,
+      user: {
+        id: user.id,
+        name: user.name,
+      },
+    };
+
+    return recipe;
+  }
+
+  public async update(options: UpsertRecipeOptions, id: number) {
+    const recipe = await this.prisma.recipe.update({
+      data: options,
+      where: { id },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    return recipe;
+  }
+
+  public async delete(id: number) {
+    const recipe = await this.prisma.recipe.delete({
+      where: { id },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    return recipe;
   }
 }

--- a/src/infrastructure/adapter/prisma/schema/migrations/20230424115720_add_recipe_visible_property/migration.sql
+++ b/src/infrastructure/adapter/prisma/schema/migrations/20230424115720_add_recipe_visible_property/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Recipe" ADD COLUMN     "visible" BOOLEAN NOT NULL DEFAULT false;

--- a/src/infrastructure/adapter/prisma/schema/schema.prisma
+++ b/src/infrastructure/adapter/prisma/schema/schema.prisma
@@ -66,6 +66,7 @@ model Recipe {
   servings    Int?
   steps       String[]
   type        RecipeType @default(UNSPECIFIED)
+  visible     Boolean    @default(false)
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @default(now())
 }

--- a/test/constants/isoDateRegexp.ts
+++ b/test/constants/isoDateRegexp.ts
@@ -1,0 +1,1 @@
+export const ISO_DATE_REGEXP = /^\d{4}-\d{2}-\d{2}T.+/;

--- a/test/e2e/auth/auth.spec.ts
+++ b/test/e2e/auth/auth.spec.ts
@@ -54,7 +54,6 @@ describe('Auth', () => {
 
         await supertest(testServer.serverApplication.getHttpServer())
           .post(`/auth/login`)
-          .set('Content-Type', 'application/json')
           .send(payload)
           .expect(400);
       },
@@ -72,7 +71,6 @@ describe('Auth', () => {
 
         await supertest(testServer.serverApplication.getHttpServer())
           .post(`/auth/login`)
-          .set('Content-Type', 'application/json')
           .send(payload)
           .expect(401, {
             statusCode: 401,
@@ -90,7 +88,6 @@ describe('Auth', () => {
 
       await supertest(testServer.serverApplication.getHttpServer())
         .post(`/auth/login`)
-        .set('Content-Type', 'application/json')
         .send(payload)
         .expect(200)
         .expect(({ body }) => {
@@ -150,7 +147,6 @@ describe('Auth', () => {
     it('should return a 400 error if refresh token is missing from payload', async () => {
       await supertest(testServer.serverApplication.getHttpServer())
         .post(`/auth/refresh`)
-        .set('Content-Type', 'application/json')
         .send({})
         .expect(400);
     });
@@ -158,7 +154,6 @@ describe('Auth', () => {
     it('should return a 400 error if provided refresh token is malformed', async () => {
       await supertest(testServer.serverApplication.getHttpServer())
         .post(`/auth/refresh`)
-        .set('Content-Type', 'application/json')
         .send({ refreshToken: 'malformed-token' })
         .expect(400);
     });
@@ -175,7 +170,6 @@ describe('Auth', () => {
 
       await supertest(testServer.serverApplication.getHttpServer())
         .post(`/auth/refresh`)
-        .set('Content-Type', 'application/json')
         .send({ refreshToken: invalidToken })
         .expect(401);
     });
@@ -192,7 +186,6 @@ describe('Auth', () => {
         testServer.serverApplication.getHttpServer(),
       )
         .post(`/auth/refresh`)
-        .set('Content-Type', 'application/json')
         .send({ refreshToken: initialRefreshToken })
         .expect(200);
 
@@ -201,7 +194,6 @@ describe('Auth', () => {
       // Attempt to use the same refresh token again: access should be denied
       await supertest(testServer.serverApplication.getHttpServer())
         .post(`/auth/refresh`)
-        .set('Content-Type', 'application/json')
         .send({ refreshToken: initialRefreshToken })
         .expect(401)
         .expect({
@@ -214,7 +206,6 @@ describe('Auth', () => {
       // the second refresh token obtained by exchanging the first valid refreshToken
       await supertest(testServer.serverApplication.getHttpServer())
         .post(`/auth/refresh`)
-        .set('Content-Type', 'application/json')
         .send({ refreshToken: secondRefreshToken })
         .expect({
           statusCode: 401,
@@ -243,14 +234,12 @@ describe('Auth', () => {
       // Use first session refresh token to get a new accessToken / refreshToken pair
       await supertest(testServer.serverApplication.getHttpServer())
         .post(`/auth/refresh`)
-        .set('Content-Type', 'application/json')
         .send({ refreshToken: firstSessionRefreshToken })
         .expect(200);
 
       // Attempt to use the same refresh token again: access should be denied
       await supertest(testServer.serverApplication.getHttpServer())
         .post(`/auth/refresh`)
-        .set('Content-Type', 'application/json')
         .send({ refreshToken: firstSessionRefreshToken })
         .expect(401)
         .expect({

--- a/test/e2e/fixtures/AuthFixture.ts
+++ b/test/e2e/fixtures/AuthFixture.ts
@@ -27,6 +27,15 @@ export class AuthFixture {
     return refreshToken;
   }
 
+  public generateAccessToken(
+    payload: Record<string, any>,
+    secret = ApiConfig.ACCESS_TOKEN_SECRET,
+  ) {
+    const accessToken = sign(payload, secret);
+
+    return accessToken;
+  }
+
   public static create(testingModule: TestingModule): AuthFixture {
     return new AuthFixture(testingModule);
   }

--- a/test/e2e/recipes/recipes.spec.ts
+++ b/test/e2e/recipes/recipes.spec.ts
@@ -8,17 +8,42 @@ import { RecipeDto } from '@core/domain/dto/recipe/RecipeDto';
 import { Recipe } from '@core/domain/entities/Recipe';
 import { instanceToPlain } from 'class-transformer';
 import { orderItems } from '@test/utils/orderItems';
+import { AuthFixture } from '../fixtures/AuthFixture';
+import { User } from '@core/domain/entities/User';
+import { ISO_DATE_REGEXP } from '@test/constants/isoDateRegexp';
 
 describe('Recipes', () => {
   let testServer: TestServer;
   let userFixture: UserFixture;
   let recipeFixture: RecipeFixture;
+  let authFixture: AuthFixture;
+
+  const insertUser = async (payload: Partial<User> = {}) =>
+    userFixture.insertOne({
+      name: 'John',
+      email: 'john@smith.com',
+      password: 'temporary',
+      roles: ['AUTHOR'],
+      ...payload,
+    });
+
+  const insertUserAndLogin = async (payload: Partial<User> = {}) => {
+    const user = await insertUser(payload);
+
+    const tokens = await authFixture.login(
+      user.email,
+      payload.password || 'temporary',
+    );
+
+    return { user, tokens };
+  };
 
   beforeAll(async () => {
     testServer = await TestServer.create();
 
     userFixture = UserFixture.create(testServer.testingModule);
     recipeFixture = RecipeFixture.create(prisma, userFixture);
+    authFixture = AuthFixture.create(testServer.testingModule);
 
     await testServer.serverApplication.init();
   });
@@ -32,7 +57,7 @@ describe('Recipes', () => {
   describe('GET /recipes', () => {
     let recipes: Recipe[];
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       await clearDb();
 
       recipes = await recipeFixture.insertMany([{}, {}]);
@@ -50,6 +75,472 @@ describe('Recipes', () => {
           data: orderItems(data),
           count: 2,
         });
+    });
+  });
+
+  describe('POST /recipes', () => {
+    beforeEach(async () => {
+      await clearDb();
+    });
+
+    it('should return a 401 error if bearer token is missing', async () => {
+      await supertest(testServer.serverApplication.getHttpServer())
+        .post('/recipes')
+        .send({
+          name: 'Cool recipe',
+        })
+        .expect(401)
+        .expect({
+          statusCode: 401,
+          message: 'Unauthorized',
+        });
+    });
+
+    it('should return a 401 error if bearer token is invalid', async () => {
+      const user = await insertUser();
+      const invalidToken = authFixture.generateAccessToken(
+        {
+          sub: user.id,
+          roles: ['ADMIN'],
+        },
+        'invalid-secret',
+      );
+
+      await supertest(testServer.serverApplication.getHttpServer())
+        .post('/recipes')
+        .set('Authorization', `Bearer ${invalidToken}`)
+        .send({
+          name: 'Cool recipe',
+        })
+        .expect(401)
+        .expect({
+          statusCode: 401,
+          message: 'Invalid Access Token',
+          error: 'Unauthorized',
+        });
+    });
+
+    it('should return a 400 error if request body is invalid', async () => {
+      const { tokens } = await insertUserAndLogin();
+
+      await supertest(testServer.serverApplication.getHttpServer())
+        .post('/recipes')
+        .set('Authorization', `Bearer ${tokens.access_token}`)
+        .send({
+          name: 'Cool recipe',
+          invalid: 'property',
+          cooking: 'abc',
+        })
+        .expect(400)
+        .expect({
+          statusCode: 400,
+          message: [
+            'property invalid should not exist',
+            'cooking must be an integer number',
+          ],
+          error: 'Bad Request',
+        });
+    });
+
+    it('should create a minimal recipe', async () => {
+      const minimalRecipeCommonFields = {
+        id: 1,
+        cooking: null,
+        description: null,
+        ingredients: [],
+        name: null,
+        note: null,
+        preparation: null,
+        price: null,
+        season: 'UNSPECIFIED',
+        servings: null,
+        steps: [],
+        type: 'UNSPECIFIED',
+        visible: false,
+      };
+
+      const { tokens, user } = await insertUserAndLogin();
+
+      await supertest(testServer.serverApplication.getHttpServer())
+        .post('/recipes')
+        .set('Authorization', `Bearer ${tokens.access_token}`)
+        .send({})
+        .expect(201)
+        .expect(({ body }) => {
+          expect(body).toMatchObject({
+            ...minimalRecipeCommonFields,
+            createdAt: expect.stringMatching(ISO_DATE_REGEXP),
+            updatedAt: expect.stringMatching(ISO_DATE_REGEXP),
+            author: { id: 1, name: 'John' },
+          });
+        });
+
+      const recipes = await prisma.recipe.findMany();
+
+      expect(recipes.length).toEqual(1);
+      expect(recipes[0]).toMatchObject({
+        ...minimalRecipeCommonFields,
+        userId: user.id,
+      });
+    });
+
+    it('should create a complete recipe', async () => {
+      const completeRecipeCommonFields = {
+        cooking: 30,
+        description: 'Cool recipe',
+        ingredients: ['Salt', 'Flour', 'Water'],
+        name: 'Pie',
+        note: 'You can also add other stuff',
+        preparation: 20,
+        price: 1000,
+        season: 'WINTER',
+        servings: 4,
+        steps: ['Cut the vegetables', '???', 'Profit'],
+        type: 'MAIN',
+        visible: true,
+      };
+
+      const { tokens, user } = await insertUserAndLogin();
+
+      await supertest(testServer.serverApplication.getHttpServer())
+        .post('/recipes')
+        .set('Authorization', `Bearer ${tokens.access_token}`)
+        .send({
+          cooking: 30,
+          description: 'Cool recipe',
+          ingredients: ['Salt', 'Flour', 'Water'],
+          name: 'Pie',
+          note: 'You can also add other stuff',
+          preparation: 20,
+          price: 1000,
+          season: 'WINTER',
+          servings: 4,
+          steps: ['Cut the vegetables', '???', 'Profit'],
+          type: 'MAIN',
+          visible: true,
+        })
+        .expect(201)
+        .expect(({ body }) => {
+          expect(body).toMatchObject({
+            ...completeRecipeCommonFields,
+            id: 1,
+            createdAt: expect.stringMatching(ISO_DATE_REGEXP),
+            updatedAt: expect.stringMatching(ISO_DATE_REGEXP),
+            author: { id: 1, name: 'John' },
+          });
+        });
+
+      const recipes = await prisma.recipe.findMany();
+
+      expect(recipes.length).toEqual(1);
+      expect(recipes[0]).toMatchObject({
+        ...completeRecipeCommonFields,
+        id: 1,
+        userId: user.id,
+      });
+    });
+
+    it('should return a 401 error if user does not have appropriate roles', async () => {
+      const { tokens } = await insertUserAndLogin({ roles: ['VIEWER'] });
+
+      await supertest(testServer.serverApplication.getHttpServer())
+        .post('/recipes')
+        .set('Authorization', `Bearer ${tokens.access_token}`)
+        .send({})
+        .expect(401)
+        .expect({
+          statusCode: 401,
+          message:
+            'User does not have the necessary role to perform this request.',
+          error: 'Unauthorized',
+        });
+    });
+
+    it('should allow admins to create recipes', async () => {
+      const { tokens } = await insertUserAndLogin({ roles: ['ADMIN'] });
+
+      await supertest(testServer.serverApplication.getHttpServer())
+        .post('/recipes')
+        .set('Authorization', `Bearer ${tokens.access_token}`)
+        .send({})
+        .expect(201);
+    });
+  });
+
+  describe('PATCH /recipes/:id', () => {
+    beforeEach(async () => {
+      await clearDb();
+    });
+
+    it('should return a 401 error if bearer token is missing', async () => {
+      await supertest(testServer.serverApplication.getHttpServer())
+        .patch('/recipes/1')
+        .send({
+          name: 'Cool recipe',
+        })
+        .expect(401)
+        .expect({
+          statusCode: 401,
+          message: 'Unauthorized',
+        });
+    });
+
+    it('should return a 401 error if bearer token is invalid', async () => {
+      const user = await insertUser();
+      const invalidToken = authFixture.generateAccessToken(
+        {
+          sub: user.id,
+          roles: ['ADMIN'],
+        },
+        'invalid-secret',
+      );
+
+      await supertest(testServer.serverApplication.getHttpServer())
+        .patch('/recipes/1')
+        .set('Authorization', `Bearer ${invalidToken}`)
+        .send({
+          name: 'Cool recipe',
+        })
+        .expect(401)
+        .expect({
+          statusCode: 401,
+          message: 'Invalid Access Token',
+          error: 'Unauthorized',
+        });
+    });
+
+    it('should return a 400 error if request body is invalid', async () => {
+      const { tokens, user } = await insertUserAndLogin();
+
+      const recipe = await recipeFixture.insertOne({
+        userId: user.id,
+      });
+
+      await supertest(testServer.serverApplication.getHttpServer())
+        .patch(`/recipes/${recipe.id}`)
+        .set('Authorization', `Bearer ${tokens.access_token}`)
+        .send({
+          name: 'Cool recipe',
+          invalid: 'property',
+          ingredients: 'abc',
+        })
+        .expect(400)
+        .expect({
+          statusCode: 400,
+          message: [
+            'property invalid should not exist',
+            'ingredients must be an array',
+          ],
+          error: 'Bad Request',
+        });
+    });
+
+    it('should update an existing recipe', async () => {
+      const { tokens, user } = await insertUserAndLogin();
+
+      const recipe = await recipeFixture.insertOne({
+        userId: user.id,
+      });
+
+      await supertest(testServer.serverApplication.getHttpServer())
+        .patch(`/recipes/${recipe.id}`)
+        .set('Authorization', `Bearer ${tokens.access_token}`)
+        .send({
+          name: 'Updated recipe name',
+        })
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body).toMatchObject({
+            name: 'Updated recipe name',
+          });
+        });
+
+      const recipes = await prisma.recipe.findMany();
+
+      expect(recipes.length).toEqual(1);
+      expect(recipes[0]).toMatchObject({
+        name: 'Updated recipe name',
+      });
+    });
+
+    it('should not allow a different author to update a recipe', async () => {
+      const user = await insertUser();
+
+      const recipe = await recipeFixture.insertOne({
+        userId: user.id,
+      });
+
+      const { tokens } = await insertUserAndLogin({
+        email: 'other@user.com',
+      });
+
+      await supertest(testServer.serverApplication.getHttpServer())
+        .patch(`/recipes/${recipe.id}`)
+        .set('Authorization', `Bearer ${tokens.access_token}`)
+        .send({
+          name: 'Updated recipe name',
+        })
+        .expect(401)
+        .expect({
+          statusCode: 401,
+          message: 'User does not own this recipe.',
+          error: 'Unauthorized',
+        });
+
+      const recipes = await prisma.recipe.findMany();
+
+      expect(recipes.length).toEqual(1);
+      expect(recipes[0]).toMatchObject({
+        name: null,
+      });
+    });
+
+    it('should allow admins to update any recipe', async () => {
+      const user = await insertUser();
+
+      const recipe = await recipeFixture.insertOne({
+        userId: user.id,
+      });
+
+      const { tokens } = await insertUserAndLogin({
+        email: 'other@user.com',
+        roles: ['ADMIN'],
+      });
+
+      await supertest(testServer.serverApplication.getHttpServer())
+        .patch(`/recipes/${recipe.id}`)
+        .set('Authorization', `Bearer ${tokens.access_token}`)
+        .send({
+          name: 'Updated recipe name',
+        })
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body).toMatchObject({
+            name: 'Updated recipe name',
+          });
+        });
+
+      const recipes = await prisma.recipe.findMany();
+
+      expect(recipes.length).toEqual(1);
+      expect(recipes[0]).toMatchObject({
+        name: 'Updated recipe name',
+      });
+    });
+  });
+
+  describe('DELETE /recipes/:id', () => {
+    beforeEach(async () => {
+      await clearDb();
+    });
+
+    it('should return a 401 error if bearer token is missing', async () => {
+      await supertest(testServer.serverApplication.getHttpServer())
+        .delete('/recipes/1')
+        .expect(401)
+        .expect({
+          statusCode: 401,
+          message: 'Unauthorized',
+        });
+    });
+
+    it('should return a 401 error if bearer token is invalid', async () => {
+      const user = await insertUser();
+      const invalidToken = authFixture.generateAccessToken(
+        {
+          sub: user.id,
+          roles: ['ADMIN'],
+        },
+        'invalid-secret',
+      );
+
+      await supertest(testServer.serverApplication.getHttpServer())
+        .delete('/recipes/1')
+        .set('Authorization', `Bearer ${invalidToken}`)
+        .expect(401)
+        .expect({
+          statusCode: 401,
+          message: 'Invalid Access Token',
+          error: 'Unauthorized',
+        });
+    });
+
+    it('should delete an existing recipe', async () => {
+      const { tokens, user } = await insertUserAndLogin();
+
+      const recipe = await recipeFixture.insertOne({
+        userId: user.id,
+      });
+
+      await supertest(testServer.serverApplication.getHttpServer())
+        .delete(`/recipes/${recipe.id}`)
+        .set('Authorization', `Bearer ${tokens.access_token}`)
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body).toMatchObject({
+            id: recipe.id,
+          });
+        });
+
+      const recipes = await prisma.recipe.findMany();
+
+      expect(recipes.length).toEqual(0);
+    });
+
+    it('should not allow a different author to delete a recipe', async () => {
+      const user = await insertUser();
+
+      const recipe = await recipeFixture.insertOne({
+        userId: user.id,
+      });
+
+      const { tokens } = await insertUserAndLogin({
+        email: 'other@user.com',
+      });
+
+      await supertest(testServer.serverApplication.getHttpServer())
+        .delete(`/recipes/${recipe.id}`)
+        .set('Authorization', `Bearer ${tokens.access_token}`)
+        .expect(401)
+        .expect({
+          statusCode: 401,
+          message: 'User does not own this recipe.',
+          error: 'Unauthorized',
+        });
+
+      const recipes = await prisma.recipe.findMany();
+
+      expect(recipes.length).toEqual(1);
+      expect(recipes[0]).toMatchObject({
+        id: recipe.id,
+      });
+    });
+
+    it('should allow admins to update any recipe', async () => {
+      const user = await insertUser();
+
+      const recipe = await recipeFixture.insertOne({
+        userId: user.id,
+      });
+
+      const { tokens } = await insertUserAndLogin({
+        email: 'other@user.com',
+        roles: ['ADMIN'],
+      });
+
+      await supertest(testServer.serverApplication.getHttpServer())
+        .delete(`/recipes/${recipe.id}`)
+        .set('Authorization', `Bearer ${tokens.access_token}`)
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body).toMatchObject({
+            id: recipe.id,
+          });
+        });
+
+      const recipes = await prisma.recipe.findMany();
+
+      expect(recipes.length).toEqual(0);
     });
   });
 });

--- a/test/e2e/users/users.spec.ts
+++ b/test/e2e/users/users.spec.ts
@@ -106,6 +106,17 @@ describe('Users', () => {
       },
     );
 
+    it('should not accept extra properties in request body', async () => {
+      await supertest(testServer.serverApplication.getHttpServer())
+        .post(`/users`)
+        .send({
+          email: 'jean.dupont@email.com',
+          password: 'temporary',
+          roles: ['ADMIN'],
+        })
+        .expect(400);
+    });
+
     it('should properly create a new user', async () => {
       const email = 'jean.dupont@email.com';
       const name = 'super-dupont';

--- a/test/e2e/users/users.spec.ts
+++ b/test/e2e/users/users.spec.ts
@@ -82,7 +82,6 @@ describe('Users', () => {
 
       await supertest(testServer.serverApplication.getHttpServer())
         .post(`/users`)
-        .set('Content-Type', 'application/json')
         .send({
           email: 'JoHn@SmItH.CoM',
           password: 'temporary',
@@ -102,7 +101,6 @@ describe('Users', () => {
 
         await supertest(testServer.serverApplication.getHttpServer())
           .post(`/users`)
-          .set('Content-Type', 'application/json')
           .send(payload)
           .expect(400);
       },
@@ -114,7 +112,6 @@ describe('Users', () => {
 
       await supertest(testServer.serverApplication.getHttpServer())
         .post(`/users`)
-        .set('Content-Type', 'application/json')
         .send({
           email,
           password: 'temporary',
@@ -139,7 +136,6 @@ describe('Users', () => {
 
       await supertest(testServer.serverApplication.getHttpServer())
         .post(`/users`)
-        .set('Content-Type', 'application/json')
         .send({
           email,
           password: 'temporary',


### PR DESCRIPTION
### Context

For now, we were only exposing an endpoint to get a list of recipes.

In this PR we will extend the recipe module to include create, update and delete operations.

### Content

The first step in implementing this functionality is adding proper Authorization, which we are doing with several guards:
* AuthGuard, to verify access token validity and attach user to the context request
* RolesGuard, to verify user has appropriate role to perform an operation
* RecipeOwnerGuard, to verify the user is the owner of the recipe, or an admin. Any 'mutating' operation can only be performed by such owner or admin.

Besides that, the implementation is quite straightforward as we are able to leverage a lot of nestjs existing functionality.

### Some notes

For now we are using a hard delete for recipes. Ultimately this will be adjusted to include an audit log trail to these operations, to be able to recover data without bloating the main recipe table.

Additionally, we did not add a `GET /recipes/:id` endpoint for now, but we will most likely need it in the future, an independent PR will be opened for that. 