### PR TITLE
Fix procfile process name

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-api: "npm run start:prod"
+web: npm run start:prod


### PR DESCRIPTION
We must use the "web" name for the main process name.