### PR TITLE
Add mappers for repositories

### DIFF
--- a/apps/api/src/core/domain/dto/recipe/RecipeDto.ts
+++ b/apps/api/src/core/domain/dto/recipe/RecipeDto.ts
@@ -125,7 +125,9 @@ export class RecipeDto {
 
     const dto = plainToInstance(RecipeDto, recipeRest);
 
-    dto.author = user;
+    if (user) {
+      dto.author = user;
+    }
 
     dto.createdAt = recipe.createdAt.toISOString();
     dto.updatedAt = recipe.updatedAt.toISOString();

--- a/apps/api/src/core/domain/entities/Recipe.ts
+++ b/apps/api/src/core/domain/entities/Recipe.ts
@@ -3,21 +3,23 @@ import { Season } from '../../common/enums/Season';
 import { User } from './User';
 
 export class Recipe {
-  id: number;
-  userId: number;
-  cooking?: number | null;
-  description?: string | null;
-  ingredients: string[];
-  name?: string | null;
-  note?: string | null;
-  preparation?: number | null;
-  price?: number | null;
-  season: `${Season}`;
-  servings?: number | null;
-  steps: string[];
-  type: `${RecipeType}`;
-  createdAt: Date;
-  updatedAt: Date;
-  user: Pick<User, 'id' | 'name'>;
-  visible: boolean;
+  constructor(
+    public id: number,
+    public userId: number,
+    public ingredients: string[],
+    public season: `${Season}`,
+    public type: `${RecipeType}`,
+    public steps: string[],
+    public createdAt: Date,
+    public updatedAt: Date,
+    public visible: boolean,
+    public user?: Pick<User, 'id' | 'name'>,
+    public cooking?: number | null,
+    public description?: string | null,
+    public name?: string | null,
+    public note?: string | null,
+    public preparation?: number | null,
+    public price?: number | null,
+    public servings?: number | null,
+  ) {}
 }

--- a/apps/api/src/core/domain/entities/RefreshToken.ts
+++ b/apps/api/src/core/domain/entities/RefreshToken.ts
@@ -1,8 +1,10 @@
 export class RefreshToken {
-  id: number;
-  userId: number;
-  jti: string;
-  family: string;
-  expiresAt: Date;
-  createdAt: Date;
+  constructor(
+    public id: number,
+    public userId: number,
+    public jti: string,
+    public family: string,
+    public expiresAt: Date,
+    public createdAt: Date,
+  ) {}
 }

--- a/apps/api/src/core/domain/entities/User.ts
+++ b/apps/api/src/core/domain/entities/User.ts
@@ -3,15 +3,17 @@ import { Role } from '../../common/enums/Role';
 import { RefreshToken } from './RefreshToken';
 
 export class User {
-  id: number;
-  email: string;
-  name: string;
-  password: string;
-  recipes?: Recipe[];
-  roles: `${Role}`[];
-  refreshTokens?: RefreshToken[];
-  createdAt: Date;
-  updatedAt: Date;
+  constructor(
+    public id: number,
+    public email: string,
+    public name: string,
+    public password: string,
+    public roles: `${Role}`[],
+    public createdAt: Date,
+    public updatedAt: Date,
+    public recipes?: Recipe[],
+    public refreshTokens?: RefreshToken[],
+  ) {}
 }
 
 export type ContextUser = Pick<User, 'id' | 'email' | 'roles' | 'name'>;

--- a/apps/api/src/infrastructure/adapter/prisma/mapper/RecipeMapper.ts
+++ b/apps/api/src/infrastructure/adapter/prisma/mapper/RecipeMapper.ts
@@ -1,0 +1,40 @@
+import { Recipe } from '@core/domain/entities/Recipe';
+import { Recipe as PrismaRecipe } from '@prisma/client';
+
+type PrismaRecipeWithRelations = PrismaRecipe & {
+  user?: { id: number; name: string };
+};
+
+export class RecipeMapper {
+  public static toDomainEntity(
+    prismaRecipe: PrismaRecipeWithRelations,
+  ): Recipe {
+    return new Recipe(
+      prismaRecipe.id,
+      prismaRecipe.userId,
+      prismaRecipe.ingredients,
+      prismaRecipe.season,
+      prismaRecipe.type,
+      prismaRecipe.steps,
+      prismaRecipe.createdAt,
+      prismaRecipe.updatedAt,
+      prismaRecipe.visible,
+      prismaRecipe.user,
+      prismaRecipe.cooking,
+      prismaRecipe.description,
+      prismaRecipe.name,
+      prismaRecipe.note,
+      prismaRecipe.preparation,
+      prismaRecipe.price,
+      prismaRecipe.servings,
+    );
+  }
+
+  public static toDomainEntities(
+    prismaRecipes: PrismaRecipeWithRelations[],
+  ): Recipe[] {
+    return prismaRecipes.map((prismaRecipe) =>
+      this.toDomainEntity(prismaRecipe),
+    );
+  }
+}

--- a/apps/api/src/infrastructure/adapter/prisma/mapper/RefreshTokenMapper.ts
+++ b/apps/api/src/infrastructure/adapter/prisma/mapper/RefreshTokenMapper.ts
@@ -1,0 +1,25 @@
+import { RefreshToken } from '@core/domain/entities/RefreshToken';
+import { RefreshToken as PrismaRefreshToken } from '@prisma/client';
+
+export class RefreshTokenMapper {
+  public static toDomainEntity(
+    prismaRefreshToken: PrismaRefreshToken,
+  ): RefreshToken {
+    return new RefreshToken(
+      prismaRefreshToken.id,
+      prismaRefreshToken.userId,
+      prismaRefreshToken.jti,
+      prismaRefreshToken.family,
+      prismaRefreshToken.expiresAt,
+      prismaRefreshToken.createdAt,
+    );
+  }
+
+  public static toDomainEntities(
+    prismaRefreshTokens: PrismaRefreshToken[],
+  ): RefreshToken[] {
+    return prismaRefreshTokens.map((prismaRefreshToken) =>
+      this.toDomainEntity(prismaRefreshToken),
+    );
+  }
+}

--- a/apps/api/src/infrastructure/adapter/prisma/mapper/UserMapper.ts
+++ b/apps/api/src/infrastructure/adapter/prisma/mapper/UserMapper.ts
@@ -1,0 +1,36 @@
+import { User } from '@core/domain/entities/User';
+import { User as PrismaUser, Recipe, RefreshToken } from '@prisma/client';
+import { RecipeMapper } from './RecipeMapper';
+import { RefreshTokenMapper } from './RefreshTokenMapper';
+
+type PrismaUserWithRelations = PrismaUser & {
+  recipes?: Recipe[];
+  refreshTokens?: RefreshToken[];
+};
+
+export class UserMapper {
+  public static toDomainEntity(prismaUser: PrismaUserWithRelations): User {
+    const recipes = RecipeMapper.toDomainEntities(prismaUser.recipes || []);
+    const refreshTokens = RefreshTokenMapper.toDomainEntities(
+      prismaUser.refreshTokens || [],
+    );
+
+    return new User(
+      prismaUser.id,
+      prismaUser.email,
+      prismaUser.name,
+      prismaUser.password,
+      prismaUser.roles,
+      prismaUser.createdAt,
+      prismaUser.updatedAt,
+      recipes,
+      refreshTokens,
+    );
+  }
+
+  public static toDomainEntities(
+    prismaUsers: PrismaUserWithRelations[],
+  ): User[] {
+    return prismaUsers.map((prismaUser) => this.toDomainEntity(prismaUser));
+  }
+}

--- a/apps/api/src/infrastructure/adapter/prisma/repository/Recipe.ts
+++ b/apps/api/src/infrastructure/adapter/prisma/repository/Recipe.ts
@@ -7,8 +7,9 @@ import {
 import { Injectable } from '@nestjs/common';
 import { PrismaClient } from '../client/PrismaClient';
 import { ApiConfig } from '@infrastructure/config/Api';
-import { Recipe } from '@core/domain/entities/Recipe';
 import { ContextUser } from '@core/domain/entities/User';
+import { RecipeMapper } from '../mapper/RecipeMapper';
+import { Recipe } from '@core/domain/entities/Recipe';
 
 const DEFAULT_PAGE_SIZE = 50;
 
@@ -29,12 +30,14 @@ export class RecipeRepository implements RecipePort {
       },
     });
 
+    if (recipe) {
+      return RecipeMapper.toDomainEntity(recipe);
+    }
+
     return recipe;
   }
 
-  public async getList(
-    options?: ListOptions<Recipe>,
-  ): Promise<readonly [Recipe[], number]> {
+  public async getList(options?: ListOptions<Recipe>) {
     const commonOptionsWithDefaults = {
       take: ApiConfig.DEFAULT_PAGE_SIZE || DEFAULT_PAGE_SIZE,
       ...options,
@@ -62,7 +65,7 @@ export class RecipeRepository implements RecipePort {
       this.prisma.recipe.count(commonOptionsWithDefaults),
     ]);
 
-    return [recipes, count] as const;
+    return [RecipeMapper.toDomainEntities(recipes), count] as const;
   }
 
   public async create(options: UpsertRecipeOptions, user: ContextUser) {
@@ -70,7 +73,7 @@ export class RecipeRepository implements RecipePort {
       data: { ...options, userId: user.id },
     });
 
-    const recipe: Recipe = {
+    const recipe = {
       ...persistedRecipe,
       user: {
         id: user.id,
@@ -78,7 +81,7 @@ export class RecipeRepository implements RecipePort {
       },
     };
 
-    return recipe;
+    return RecipeMapper.toDomainEntity(recipe);
   }
 
   public async update(options: UpsertRecipeOptions, id: number) {
@@ -95,7 +98,7 @@ export class RecipeRepository implements RecipePort {
       },
     });
 
-    return recipe;
+    return RecipeMapper.toDomainEntity(recipe);
   }
 
   public async delete(id: number) {
@@ -111,6 +114,6 @@ export class RecipeRepository implements RecipePort {
       },
     });
 
-    return recipe;
+    return RecipeMapper.toDomainEntity(recipe);
   }
 }

--- a/apps/api/src/infrastructure/adapter/prisma/repository/RefreshToken.ts
+++ b/apps/api/src/infrastructure/adapter/prisma/repository/RefreshToken.ts
@@ -8,6 +8,7 @@ import {
 import { ListOptions } from '@core/common/persistence/ListOptions';
 import { RefreshToken } from '@core/domain/entities/RefreshToken';
 import { DeleteManyOptions } from '@core/common/persistence/DeleteManyOptions';
+import { RefreshTokenMapper } from '../mapper/RefreshTokenMapper';
 
 @Injectable()
 export class RefreshTokenRepository implements RefreshTokenPort {
@@ -18,13 +19,17 @@ export class RefreshTokenRepository implements RefreshTokenPort {
       data: options,
     });
 
-    return refreshToken;
+    return RefreshTokenMapper.toDomainEntity(refreshToken);
   }
 
   async get(options: GetRefreshTokenOptions) {
     const refreshToken = await this.prisma.refreshToken.findUnique({
       where: options,
     });
+
+    if (refreshToken) {
+      return RefreshTokenMapper.toDomainEntity(refreshToken);
+    }
 
     return refreshToken;
   }
@@ -35,7 +40,7 @@ export class RefreshTokenRepository implements RefreshTokenPort {
       this.prisma.refreshToken.count(options),
     ]);
 
-    return [refreshTokens, count] as const;
+    return [RefreshTokenMapper.toDomainEntities(refreshTokens), count] as const;
   }
 
   async deleteMany(options: DeleteManyOptions<RefreshToken>) {

--- a/apps/api/src/infrastructure/adapter/prisma/repository/User.ts
+++ b/apps/api/src/infrastructure/adapter/prisma/repository/User.ts
@@ -5,6 +5,7 @@ import {
   GetUserOptions,
   UserPort,
 } from '@core/domain/ports/User';
+import { UserMapper } from '../mapper/UserMapper';
 
 @Injectable()
 export class UserRepository implements UserPort {
@@ -15,13 +16,17 @@ export class UserRepository implements UserPort {
       data: options,
     });
 
-    return user;
+    return UserMapper.toDomainEntity(user);
   }
 
   async get(options: GetUserOptions) {
     const user = await this.prisma.user.findUnique({
       where: options,
     });
+
+    if (user) {
+      return UserMapper.toDomainEntity(user);
+    }
 
     return user;
   }


### PR DESCRIPTION
### Context

For now (for simplicity reasons) we were using domain entities and prisma specific entities interchangeably. 

Even though they match mostly 1:1 for now, we should still make the distinction explicit, and they might evolve separately in the future.

### Content

* Adding a mapper for each type of entity
* Mapping prisma entities to domain entities before returning results in the various repositories