### PR TITLE
Add GET recipe endpoint

### DIFF
--- a/apps/api/src/application/api/controllers/RecipeController.ts
+++ b/apps/api/src/application/api/controllers/RecipeController.ts
@@ -34,6 +34,12 @@ export class RecipeController {
     private readonly recipeUseCases: RecipeUseCases,
   ) {}
 
+  @Get(':id')
+  @ApiResponse({ status: HttpStatus.OK, type: RecipeDto })
+  getRecipe(@Param('id', new ParseIntPipe()) id: number): Promise<RecipeDto> {
+    return this.recipeUseCases.get(id);
+  }
+
   @Get()
   @ApiResponse({ status: HttpStatus.OK, type: RecipeDtoList })
   getRecipes(

--- a/apps/api/src/core/domain/usecases/Recipe.ts
+++ b/apps/api/src/core/domain/usecases/Recipe.ts
@@ -6,6 +6,8 @@ import { UpsertRecipeDto } from '../dto/recipe/UpsertRecipeDto';
 import { ContextUser } from '../entities/User';
 
 export interface RecipeUseCases extends GenericUseCases<RecipeDto> {
+  get(id: number): Promise<RecipeDto>;
+
   getList(options?: ListOptions): Promise<RecipeDtoList>;
 
   create(payload: UpsertRecipeDto, user: ContextUser): Promise<RecipeDto>;

--- a/apps/api/src/core/services/Recipe.ts
+++ b/apps/api/src/core/services/Recipe.ts
@@ -6,7 +6,8 @@ import { RecipeDtoList } from '@core/domain/dto/recipe/RecipeDtoList';
 import { ContextUser } from '@core/domain/entities/User';
 import { RecipePort } from '@core/domain/ports/Recipe';
 import { RecipeUseCases } from '@core/domain/usecases/Recipe';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { CoreAssert } from '@core/common/utils/assert/CoreAssert';
 
 @Injectable()
 export class RecipeService implements RecipeUseCases {
@@ -14,6 +15,15 @@ export class RecipeService implements RecipeUseCases {
     @Inject(RecipeTokens.RecipePort)
     private readonly recipePort: RecipePort,
   ) {}
+
+  async get(id: number): Promise<RecipeDto> {
+    const recipe = CoreAssert.notEmpty(
+      await this.recipePort.get({ id }),
+      new NotFoundException(),
+    );
+
+    return RecipeDto.createFromRecipe(recipe);
+  }
 
   public async getList(options?: ListOptions): Promise<RecipeDtoList> {
     const [recipes, count] = await this.recipePort.getList(options);

--- a/apps/api/test/e2e/recipes/recipes.spec.ts
+++ b/apps/api/test/e2e/recipes/recipes.spec.ts
@@ -54,6 +54,46 @@ describe('Recipes', () => {
     }
   });
 
+  describe('GET /recipes/:id', () => {
+    let recipe: Recipe;
+
+    beforeAll(async () => {
+      await clearDb();
+
+      recipe = await recipeFixture.insertOne({
+        name: 'Some recipe',
+        description: 'Yummy',
+      });
+    });
+
+    it('should return properly formatted recipe', async () => {
+      await supertest(testServer.serverApplication.getHttpServer())
+        .get(`/recipes/${recipe.id}`)
+        .expect(200)
+        .expect((response) => {
+          expect(response.body.email).toBeUndefined();
+          expect(response.body.password).toBeUndefined();
+          expect(response.body.roles).toBeUndefined();
+
+          expect(response.body).toEqual(
+            instanceToPlain(RecipeDto.createFromRecipe(recipe)),
+          );
+        });
+    });
+
+    it('should return a 404 error if recipe does not exist', async () => {
+      await supertest(testServer.serverApplication.getHttpServer())
+        .get(`/recipes/9999`)
+        .expect(404);
+    });
+
+    it('should return a 400 error if id is invalid', async () => {
+      await supertest(testServer.serverApplication.getHttpServer())
+        .get(`/recipes/abcd`)
+        .expect(400);
+    });
+  });
+
   describe('GET /recipes', () => {
     let recipes: Recipe[];
 


### PR DESCRIPTION
### Context

We already had necessary service and repository logic to fetch recipes by id, and we want to expose a corresponding endpoint for our upcoming client application.

### Content

Mainly adding the controller and the corresponding e2e test.